### PR TITLE
Add JAXRS based on Aries Whiteboard

### DIFF
--- a/winegrower-cepages/winegrower-cepage-jaxrs/pom.xml
+++ b/winegrower-cepages/winegrower-cepage-jaxrs/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+            http://maven.apache.org/POM/4.0.0
+            http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.winegrower.cepages</groupId>
+    <artifactId>winegrower-cepages</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>jaxrs</artifactId>
+  <name>Apache Winegrower :: Cepages :: JAXRS</name>
+
+  <properties>
+    <cxf.version>3.2.6</cxf.version>
+    <pax-web.version>7.2.3</pax-web.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.aries.jax.rs</groupId>
+      <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.aries.component-dsl</groupId>
+      <artifactId>org.apache.aries.component-dsl.component-dsl</artifactId>
+      <version>1.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+      <version>${cxf.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-rs-client</artifactId>
+      <version>${cxf.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-rs-sse</artifactId>
+      <version>${cxf.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+    <dependency> <!-- todo: use tomcat ? -->
+      <groupId>org.ops4j.pax.web</groupId>
+      <artifactId>pax-web-jetty</artifactId>
+      <version>${pax-web.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.aggregate</groupId>
+      <artifactId>jetty-all</artifactId>
+      <classifier>uber</classifier>
+      <version>9.4.11.v20180605</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-commons</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.web</groupId>
+      <artifactId>pax-web-runtime</artifactId>
+      <version>${pax-web.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.web</groupId>
+      <artifactId>pax-web-extender-whiteboard</artifactId>
+      <version>${pax-web.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.web</groupId>
+      <artifactId>pax-web-api</artifactId>
+      <version>${pax-web.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.web</groupId>
+      <artifactId>pax-web-spi</artifactId>
+      <version>${pax-web.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.karaf.web</groupId>
+      <artifactId>org.apache.karaf.web.core</artifactId>
+      <version>${karaf.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/winegrower-examples/jaxrs-whiteboard/pom.xml
+++ b/winegrower-examples/jaxrs-whiteboard/pom.xml
@@ -25,36 +25,40 @@
 
   <parent>
     <groupId>org.apache.winegrower</groupId>
-    <artifactId>winegrower</artifactId>
+    <artifactId>winegrower-examples</artifactId>
     <version>1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <groupId>org.apache.winegrower.cepages</groupId>
-  <artifactId>winegrower-cepages</artifactId>
-  <name>Apache Winegrower :: Cepages</name>
-  <packaging>pom</packaging>
+  <groupId>org.apache.winegrower.examples</groupId>
+  <artifactId>jaxrs-whiteboard</artifactId>
+  <name>Apache Winegrower :: Examples :: JAXRS Whiteboard</name>
 
-  <properties>
-    <karaf.version>4.2.1</karaf.version>
-  </properties>
+  <description>
+    Run "mvn package winegrower:pour" then hit http://localhost:8080/cxf/api/harvest.
+  </description>
 
-  <modules>
-    <module>winegrower-cepage-shell</module>
-    <module>winegrower-cepage-cxf-rs</module>
-    <module>winegrower-cepage-jaxrs</module>
-  </modules>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.winegrower</groupId>
+      <artifactId>winegrower-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.winegrower.cepages</groupId>
+      <artifactId>jaxrs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
 
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.0</version>
-        <configuration>
-          <skipIfEmpty>true</skipIfEmpty>
-        </configuration>
+        <groupId>org.apache.winegrower</groupId>
+        <artifactId>winegrower-maven-plugin</artifactId>
+        <version>${project.version}</version>
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/winegrower-examples/jaxrs-whiteboard/src/main/java/org/apache/winegrower/examples/jaxrs/Harvest.java
+++ b/winegrower-examples/jaxrs-whiteboard/src/main/java/org/apache/winegrower/examples/jaxrs/Harvest.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.winegrower.examples.jaxrs;
+
+import org.osgi.service.component.annotations.Component;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.time.LocalDate;
+
+@Component(service = Harvest.class)
+@Path("/api/harvest")
+public class Harvest {
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public String get() {
+        return "{\"year\":\"" + LocalDate.now().getYear() + "\"}";
+    }
+}

--- a/winegrower-examples/pom.xml
+++ b/winegrower-examples/pom.xml
@@ -41,6 +41,7 @@
     <!-- <module>scr</module> -->
     <module>shell</module>
     <module>jaxrs</module>
+    <module>jaxrs-whiteboard</module>
     <!-- <module>monitoring</module> -->
     <!-- <module>cdi</module> -->
     <!-- <module>spring</module> -->


### PR DESCRIPTION
I introduced a cepage based on Aries JAXRS Whiteboard. It allows to use directly scr and avoid blueprint.

I wonder if it won't make sense to rename `cxf-rs` cepage in just `jaxrs` and provide both blueprint approach or whiteboard approach for the user.

Thoughts ?